### PR TITLE
DO NOT MERGE: Expressions

### DIFF
--- a/src/Mathjs/Expression.js
+++ b/src/Mathjs/Expression.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var mathjs = require("mathjs");
+
+exports._compile = function(expr) {
+  return function() {
+    return mathjs.compile(expr);
+  }
+}
+
+function demux( constructors, res ) {
+  var rval = constructors.undef
+  var rtype = typeof res
+  if( rtype === 'boolean' ) {
+    rval = constructors.bool(res)
+  } else if( rtype === 'number') {
+    rval = constructors.number(res)
+  } else if ( rtype === 'string' ) {
+    rval = constructors.string(res)
+  } else if ( rtype === 'object') {
+    if( res.type === 'DenseMatrix' ) {
+      if( res._size.length == 1 ) {
+        rval = constructors.vector(res)
+      } else if ( res._size.length == 2 ) {
+        rval = constructors.matrix(res)
+      }
+    } else if ( res.type === 'ResultSet') {
+      rval = constructors.set( res.entries.map( function(e) { return demux( constructors, e ) } ) )
+    } else if( res.type === 'BigNumber') {
+      rval = constructors.bignumber(res)
+    } else if( res.type === 'Fraction') {
+      rval = constructors.fraction(res)
+    } else if( res.type === 'Complex') {
+      rval = constructors.complex(res)
+    } else if ( !res.type ) {
+      const pairs = Object.keys(res).map( function(key) {
+          var val = demux( constructors, res[key] )
+          return constructors.pair(key)(val)
+        })
+      rval = constructors.obj(pairs)
+    } else {
+      console.log("Typed but unknown", res.type, res.re, res.im, res[0] )
+    }
+  }
+  // console.log('demux', res, rtype, rval);
+  return rval;
+}
+
+// The expression parser supports booleans, numbers, complex numbers, units, strings, matrices, and objects.
+// Units
+exports._eval =
+  function( eo ) {
+    return function( constructors ) {
+      return function( exp ) {
+        return function( scope ) {
+          return function() {
+            var sc = Object.assign({}, scope)
+            var res = exp.eval(sc)
+            var rval = demux( constructors, res )
+            // console.log('eval', rval, scope )
+            return eo(rval)(sc)
+          }
+        }
+      }
+    }
+  }

--- a/src/Mathjs/Expression.purs
+++ b/src/Mathjs/Expression.purs
@@ -1,0 +1,187 @@
+module Mathjs.Expression where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+import Data.Tuple as T
+
+import Control.Monad.Eff (Eff, kind Effect)
+import Control.Monad.Eff.Exception (Error, EXCEPTION)
+
+import Mathjs.Matrix (MatrixF)
+import Mathjs.Vector (VectorF)
+import Mathjs.Util (MATHJS)
+
+type Scope r = { | r }
+
+type BigNumberF = { d :: Array Number, e :: Number, s :: Number }
+type FractionF = {s :: Number, n :: Number, d :: Number}
+type ComplexF = { re :: Number, im :: Number }
+
+ -- // The expression parser supports booleans, numbers, bignumber, complex numbers, units, strings, matrices, and objects.
+data Result =
+  Boolean Boolean
+  | Number Number
+  | BigNumber BigNumberF
+  | Fraction FractionF
+  | Complex ComplexF
+  -- | Unit UnitF
+  | String String
+  | Vector VectorF
+  | Matrix MatrixF
+  | Object (Array (Tuple String Result))
+  | ResultSet (Array Result)
+  | Exception Error
+  | Undefined
+
+instance showResult :: Show Result where
+  show (Boolean a) = "(Boolean " <> show a <> ")"
+  show (Number a) = "(Number " <> show a <> ")"
+  show (BigNumber a) = "(BigNumber " <> show a.d <> " " <> show a.e <> " " <> show a.s <> ")"
+  show (Fraction a) = "(Fraction " <> show a.s <> " " <> show a.n <> " " <> show a.d <> ")"
+  show (Complex a) = "(Complex " <> show a.re <> " " <> show a.im <> ")"
+  show (String a) = "(String " <> show a <> ")"
+  show (Vector a) = "(Vector " <> show a._data <> " " <> show a._size <> ")"
+  show (Matrix a) = "(Matrix " <> show a._data <> " " <> show a._size <> ")"
+  show (Object a) = "(Object " <> show a <> ")"
+  show (ResultSet a) = "(ResultSet " <> show a <> ")"
+  show (Exception a) = "(Exception " <> show a <> ")"
+  show Undefined = "(Undefined)"
+
+instance eqResult :: Eq Result where
+  eq (Boolean a) (Boolean b) = eq a b
+  eq (Number a) (Number b) = eq a b
+  eq (BigNumber a) (BigNumber b) = (eq a.d b.d) && (eq a.e b.e) && (eq a.s b.s)
+  eq (Fraction a) (Fraction b) = (eq a.s b.s) && (eq a.n b.n) && (eq a.d b.d)
+  eq (Complex a) (Complex b) = (eq a.re b.re) && (eq a.im b.im)
+  eq (String a) (String b) = eq a b
+  eq (Vector a) (Vector b) = (eq a._data b._data) && (eq a._size b._size)
+  eq (Matrix a) (Matrix b) = (eq a._data b._data) && (eq a._size b._size)
+  eq (Object a) (Object b) = eq a b
+  eq (ResultSet a) (ResultSet b) = eq a b
+  eq (Exception a) (Exception b) = false
+  eq Undefined Undefined = true
+  eq _ _ = false
+
+isBoolean :: Result -> Boolean
+isBoolean (Boolean _) = true
+isBoolean _ = false
+
+getBoolean :: Result -> Maybe Boolean
+getBoolean (Boolean a) = pure a
+getBoolean _ = Nothing
+
+isNumber :: Result -> Boolean
+isNumber (Number _) = true
+isNumber _ = false
+
+getNumber :: Result -> Maybe Number
+getNumber (Number a) = pure a
+getNumber _ = Nothing
+
+isBigNumber :: Result -> Boolean
+isBigNumber (BigNumber _) = true
+isBigNumber _ = false
+
+getBigNumber :: Result -> Maybe BigNumberF
+getBigNumber (BigNumber a) = pure a
+getBigNumber _ = Nothing
+
+isFraction :: Result -> Boolean
+isFraction (Fraction _) = true
+isFraction _ = false
+
+getFraction :: Result -> Maybe FractionF
+getFraction (Fraction a) = pure a
+getFraction _ = Nothing
+
+isComplex :: Result -> Boolean
+isComplex (Complex _) = true
+isComplex _ = false
+
+getComplex :: Result -> Maybe ComplexF
+getComplex (Complex a) = pure a
+getComplex _ = Nothing
+
+isString :: Result -> Boolean
+isString (String _) = true
+isString _ = false
+
+getString :: Result -> Maybe String
+getString (String a) = pure a
+getString _ = Nothing
+
+isVector :: Result -> Boolean
+isVector (Vector _) = true
+isVector _ = false
+
+getVector :: Result -> Maybe VectorF
+getVector (Vector a) = pure a
+getVector _ = Nothing
+
+isMatrix :: Result -> Boolean
+isMatrix (Matrix _) = true
+isMatrix _ = false
+
+getMatrix :: Result -> Maybe MatrixF
+getMatrix (Matrix a) = pure a
+getMatrix _ = Nothing
+
+isObject :: Result -> Boolean
+isObject (Object _) = true
+isObject _ = false
+
+isResultSet :: Result -> Boolean
+isResultSet (ResultSet _) = true
+isResultSet _ = false
+
+isException :: Result -> Boolean
+isException (Exception _) = true
+isException _ = false
+
+isUndefined :: Result -> Boolean
+isUndefined Undefined = true
+isUndefined _ = false
+
+
+lookup :: Result -> String -> Maybe Result
+lookup (Object a) str = T.lookup str a
+lookup _ _ = Nothing
+
+type ExpressionF = { eval :: ∀ r eff. (Scope r) -> Eff ( mathjs :: MATHJS, exception :: EXCEPTION | eff ) (Tuple Result (Scope r)) }
+type Expression = ExpressionF
+
+foreign import _compile ::
+  ∀ eff.
+  String ->
+  Eff ( mathjs :: MATHJS, exception :: EXCEPTION | eff ) ExpressionF
+
+type Constructors = {
+  bool :: (Boolean -> Result),
+  number :: (Number -> Result),
+  bignumber :: (BigNumberF -> Result),
+  fraction :: (FractionF -> Result),
+  complex :: (ComplexF -> Result),
+  string :: (String -> Result),
+  vector :: (VectorF -> Result),
+  matrix :: (MatrixF -> Result),
+  pair :: (String -> Result -> Tuple String Result),
+  obj :: (Array (Tuple String Result) -> Result),
+  set :: (Array Result -> Result),
+  undef :: (Result)
+}
+
+foreign import _eval ::
+  ∀ r eff.
+  (Result -> (Scope r) -> Tuple Result (Scope r)) ->
+  Constructors ->
+  ExpressionF ->
+  (Scope r) ->
+  Eff ( mathjs :: MATHJS, exception :: EXCEPTION | eff ) (Tuple Result (Scope r))
+
+compile :: ∀ eff. String -> Eff ( mathjs :: MATHJS, exception :: EXCEPTION | eff) Expression
+compile = _compile
+
+eval :: ∀ r eff. Expression -> (Scope r) -> Eff ( mathjs :: MATHJS, exception :: EXCEPTION | eff ) (Tuple Result (Scope r))
+eval = _eval Tuple { bool: Boolean, number: Number, bignumber: BigNumber, fraction: Fraction, complex: Complex, string: String, vector: Vector, matrix: Matrix, pair: Tuple, obj: Object, set: ResultSet, undef: Undefined }

--- a/src/Mathjs/Util.purs
+++ b/src/Mathjs/Util.purs
@@ -11,5 +11,3 @@ instance showInvalidSize :: Show InvalidSize where
 
 instance eqInvalidSize :: Eq InvalidSize where
     eq (InvalidSize s1) (InvalidSize s2) = s1 == s2
-
-

--- a/src/Mathjs/Util.purs
+++ b/src/Mathjs/Util.purs
@@ -2,6 +2,10 @@ module Mathjs.Util where
 
 import Prelude (class Eq, class Show, (==), show, (<>))
 
+import Control.Monad.Eff (kind Effect)
+
+foreign import data MATHJS :: Effect
+
 type Numbers = Array Number
 
 data InvalidSize = InvalidSize Int

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -104,14 +104,14 @@ main = runTest do
                 let m1 = make [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
                 let r = join $ det <$> m1
                 Assert.assert "should be SquareMatrixExpected" $ r == (Left SquareMatrixExpected)
-    
+
             test "success" do
                 let m1 = make [[-2.0, 2.0, 3.0], [-1.0, 1.0, 3.0], [2.0, 0.0, -1.0]]
                 let r = join $ det <$> m1
                 Assert.assert "should be success" $ r == (Right 6.0)
 
         suite "inv" do
-    
+
             test "is not a square matrix" do
                 let m1 = make [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
                 let r = join $ inv <$> m1
@@ -124,21 +124,21 @@ main = runTest do
                 Assert.assert "should be success" $ d == (Right  [[-2.0, 1.0], [1.5, -0.5]])
 
         suite "transpose" do
-    
+
             test "success" do
                 let m1 = make [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
                 let r = getData <$> transpose <$> m1
                 Assert.assert "should be success" $ r == (Right [[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]])
 
         suite "flatten" do
-    
+
             test "success" do
                 let m1 = make [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
                 let r = getData <$> flatten <$> m1
                 Assert.assert "should be success" $ r == (Right [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
 
         suite "trace" do
-    
+
             test "is not a square matrix" do
                 let m1 = make [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
                 let r = join $ trace <$> m1
@@ -150,7 +150,7 @@ main = runTest do
                 Assert.assert "should be success" $ r == (Right 6.0)
 
         suite "diag" do
-    
+
             test "is not a square matrix" do
                 let m1 = make [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]
                 let r = join $ diag <$> m1

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,25 +1,38 @@
 module Test.Main where
 
-import Prelude
+import Prelude (Unit, bind, discard, join, map, negate, ($), (<$>), (<*>), (==), (<<<), show)
 
-import Data.Maybe 
-import Data.Either
-import Data.Tuple 
+import Data.Maybe (Maybe(..))
+import Data.Either (Either(..), fromRight, isRight, isLeft)
+import Data.Tuple (Tuple(..), fst, snd)
+import Data.Traversable (sequence)
 
-import Control.Bind
-import Control.Monad.Eff
-import Control.Monad.Eff.Console
-import Control.Monad.Eff.Class
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Exception (try, EXCEPTION)
+import Control.Monad.Eff.AVar (AVAR)
+
+import Partial.Unsafe (unsafePartial)
 
 import Test.Unit (test, suite)
+import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTest)
 import Test.Unit.Assert as Assert
 
-import Mathjs.Util
-import Mathjs.Geometry
-import Mathjs.Matrix
+-- import Mathjs.Util
+import Mathjs.Geometry (Line(..), Point2D(..), distance, intersect)
+import Mathjs.Matrix (MatrixError(..), det, diag, dot, eye, eye', flatten, getData, getSizes, inv, make, ones, ones', trace, transpose, zeros, zeros')
+import Mathjs.Expression as Exp
+import Mathjs.Util (MATHJS)
 
+expresult str r = do
+  let scope = { haha: "Haha" }
+  cmp <- liftEff $ Exp.compile str
+  ev <- liftEff $ Exp.eval cmp scope
+  Assert.assert "Evaluates to Boolean" $ r == (fst ev)
 
+main :: forall eff. Eff ( console :: CONSOLE , testOutput :: TESTOUTPUT , avar :: AVAR, mathjs :: MATHJS, exception :: EXCEPTION | eff ) Unit
 main = runTest do
     suite "Geometry" do
 
@@ -36,6 +49,45 @@ main = runTest do
             let l3 = Line (Point2D 2.0 8.0) (Point2D 10.0 8.0) -- same as above
             Assert.assert "should be intersect at 5.0 8.0" $ (intersect l1 l2) == Just (Point2D 5.0 8.0)
             Assert.assert "should not intersect" $ (intersect l2 l2) == Nothing
+
+    suite "Expression" do
+      suite "Compilation" do
+        test "success" do
+          let str = "x = 3"
+          cmp <- liftEff $ try $ Exp.compile str
+          Assert.assert "Compiles good" $ isRight cmp
+
+        test "failure" do
+          let str = "x ="
+          cmp <- liftEff $ try $ Exp.compile str
+          Assert.assert "Compiles bad" $ isLeft cmp
+
+      suite "Eval" do
+        test "eval boolean" $ expresult "x = false" (Exp.Boolean false)
+        test "eval number" $ expresult "x = 3" (Exp.Number 3.0)
+        test "eval bignumber" $ expresult "x = bignumber(100)" (Exp.BigNumber {s: 1.0, e: 2.0, d: [100.0]})
+        test "eval fraction" $ expresult "x = fraction(100, 200)" (Exp.Fraction {s: 1.0, n: 1.0, d: 2.0})
+        test "eval complex" $ expresult "x = 4 - 2i" (Exp.Complex {re: 4.0, im: -2.0})
+        test "eval string" $ expresult "x = \"hehe\"" (Exp.String "hehe")
+        test "eval vector" $ expresult "x = [1,2,3,4]" (Exp.Vector {_data: [1.0, 2.0, 3.0, 4.0], _size: [4]} )
+        test "eval matrix" $ expresult "x = [[1,2],[3,4]]" (Exp.Matrix {_data: [[1.0, 2.0], [3.0, 4.0]], _size: [2,2]})
+        test "eval object" $ expresult "x = {x: \"haha\", y: 3}" (Exp.Object [Tuple "x" (Exp.String "haha"), Tuple "y" (Exp.Number 3.0)])
+
+        test "eval exception" do
+          let str = "x = 3/\"haha\""
+          let scope = { haha: "Haha" }
+          cmp <- liftEff $ Exp.compile str
+          ev <- liftEff $ try $ Exp.eval cmp scope
+          Assert.assert "Evaluates to Exception" $ isLeft ev
+
+        test "set scope" do
+          let str = "haha = \"nono\""
+          let scope = { haha: "Haha" }
+          cmp <- liftEff $ Exp.compile str
+          ev <- liftEff $ Exp.eval cmp scope
+          Assert.assert "Evaluates to String" $ (Exp.String "nono") == (fst ev)
+          Assert.assert "assigns nono" $ "nono" == ( _.haha $ snd ev)
+
 
     suite "Matrix" do
 


### PR DESCRIPTION
Hi Rob
Here's a first pass at Expressions for MathJS

I don't think this is done, but I want to share in case anyone comes along and is looking for it.

A few details:

MathJS 4.0 just came out.  This is for 3.2.1.
Eval of a single line produces a "Result" for which there are many constructors.
Eval a line with multiple statements produces a ResultSet Result, which is actually an Array Result despite the name.

Exceptions are everywhere in mathjs eval.  I have included an Exception Result, but the core eval FFI does not catch errors. Instead, the core eval function returns  Eff ( mathjs :: MATHJS, exception :: EXCEPTION | eff ) and it is up to the calling party to catch at their preferred level.  (In my application i use catchException per line and produce an Exception )

Expressions that produce an object are difficult for PS.  We can't really anticipate the shape of these Objects so instead, this FFI returns Result Object as (Array (Tuple String Result)).  At least this way the keys and values can be interrogated. I suppose a Map would have done it too, but the Array Tuples might be easier to round trip back into objects should they be modified in PS. (Object Result modification TBD.)

Scope is again vague, so it is defined as `type Scope r = { | r }`.  I have used this to assert the existince of some core values, but maybe a more rigorous FFI would be useful to guard against changes to these core values?

I havn't included Unit type because it has a huge surface area and I didn't personally need it.
